### PR TITLE
Fix/permiso camara observaciones

### DIFF
--- a/.context/roadmap_iteracion_2.md
+++ b/.context/roadmap_iteracion_2.md
@@ -3,7 +3,7 @@
 Basado en el documento de `bugs_identificados.md`, el siguiente es el listado de problemas y mejoras a implementar durante la Iteración 2, organizados por nivel de severidad.
 
 ## 🔴 NIVEL L1 — CRASHES Y ERRORES CRÍTICOS
-- [ ] **[#283] Issue 6:** Crash al Abrir la Cámara en Observaciones (Permiso no Solicitado)
+- [x] **[#283] Issue 6:** Crash al Abrir la Cámara en Observaciones (Permiso no Solicitado)
 - [ ] **[#284] Issue 7:** Crash por Foreign Key al Registrar Cosecha (campaniaId = -1)
 
 ## 🟠 NIVEL L2 — BUGS FUNCIONALES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+**[2026-06-30] - [#283] fix: Crash al Abrir la Cámara — Permiso CAMERA no Solicitado**
+- **Causa raíz resuelta:** La app lanzaba `cameraLauncher.launch(uri)` directamente sin verificar ni solicitar el permiso `CAMERA` en runtime, causando un `SecurityException` en Android 6.0+ (API 23).
+- **Nuevo módulo creado:** `presentation/util/CameraUtils.kt` con tres responsabilidades separadas:
+  - `EstadoPermisoCamara`: State holder observable con `mutableStateOf` para `permisoConcedido`, `mostrarRazon` y `denegadoPermanente`.
+  - `recordarPermisoCamara()`: Composable que gestiona el ciclo completo del permiso usando `ActivityResultContracts.RequestPermission()` y `ActivityCompat.shouldShowRequestPermissionRationale()` para distinguir denegación temporal vs. permanente.
+  - `DialogoRazonPermisoCamara()`: `AlertDialog` de rationale que se muestra en primera denegación.
+  - `abrirAjustesPermiso()`: Helper que lanza `Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)` cuando el permiso es denegado permanentemente.
+- **`ObservacionesScreen.kt` actualizado:** Botón "Tomar foto" ahora verifica `controlPermiso.permisoConcedido` antes de lanzar la cámara. Si no está concedido, guarda la acción pendiente y llama a `controlPermiso.solicitar()`. `SnackbarHost` añadido al `Box` para feedback visual.
+- **Flujos cubiertos:** Permiso ya concedido (directo a cámara) · Primera denegación (muestra rationale) · Denegación permanente (Snackbar con botón "Abrir Ajustes").
+- **Rama:** `fix/permiso-camara-observaciones`
+
 **[2026-06-23] - Documentación de Entrega y Casos de Uso**
 - Actualización de `docs/FLOW.md` incorporando diagramas de flujo interactivos Mermaid para cada una de las 8 ramas principales del sistema.
 - Creación de `docs/diferencias_casos_de_uso_2025_2026.md` contrastando la propuesta teórica original (2025) con la implementación final en Clean Architecture (2026), aplicando el formato tabular de casos de uso requerido en la cursada.

--- a/app/src/main/java/com/itec/donelio/presentation/ui/screen/observacion/ObservacionesScreen.kt
+++ b/app/src/main/java/com/itec/donelio/presentation/ui/screen/observacion/ObservacionesScreen.kt
@@ -32,12 +32,13 @@ import coil.compose.AsyncImage
 import java.io.File
 import com.itec.donelio.domain.model.Observacion
 import com.itec.donelio.presentation.ui.components.SelectorCampania
-
-import androidx.compose.runtime.remember
 import com.itec.donelio.presentation.ui.theme.AgriFondo
 import com.itec.donelio.presentation.ui.theme.AgriVerde
 import com.itec.donelio.presentation.ui.theme.TextoPrincipal
 import com.itec.donelio.presentation.ui.theme.TextoSecundario
+import com.itec.donelio.presentation.util.DialogoRazonPermisoCamara
+import com.itec.donelio.presentation.util.abrirAjustesPermiso
+import com.itec.donelio.presentation.util.recordarPermisoCamara
 import com.itec.donelio.presentation.viewmodel.observacion.FormularioObservacionViewModel
 import com.itec.donelio.presentation.viewmodel.observacion.ObservacionViewModel
 
@@ -50,34 +51,39 @@ fun ObservacionesScreen(
     formViewModel: FormularioObservacionViewModel = hiltViewModel(),
     listViewModel: ObservacionViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val formState by formViewModel.state.collectAsState()
     val observaciones by listViewModel.observaciones.collectAsState()
     val campanias by listViewModel.campanias.collectAsState()
     val campaniaIdSeleccionada by listViewModel.campaniaIdSeleccionada.collectAsState()
-    val campaniaActiva = remember(campanias, campaniaIdSeleccionada) {
-        campanias.find { it.id == campaniaIdSeleccionada }
-    }
     val isCampaniaValid by listViewModel.isCampaniaValid.collectAsState()
 
-    LaunchedEffect(formState.guardadoExitoso) {
-        if (formState.guardadoExitoso) formViewModel.resetGuardadoExitoso()
-    }
+    // ── Gestión del permiso de cámara (CameraUtils) ──────────────────────────
+    val controlPermiso = recordarPermisoCamara()
+    val snackbarHostState = remember { SnackbarHostState() }
+    // Acción pendiente: se ejecuta tan pronto el permiso sea concedido
+    var accionPendiente by remember { mutableStateOf<(() -> Unit)?>(null) }
+    // Controla la visibilidad del diálogo de rationale
+    var mostrarDialogoRazon by remember { mutableStateOf(false) }
 
-    val context = LocalContext.current
+    // URI temporal para la foto de cámara
     var tempCameraUri by remember { mutableStateOf<Uri?>(null) }
 
-    val cameraLauncher = rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { success ->
-        if (success) {
+    // Launcher de la cámara
+    val cameraLauncher = rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { exito ->
+        if (exito) {
             formViewModel.onImagenSeleccionada(tempCameraUri)
         }
     }
 
+    // Launcher de galería (no requiere permiso peligroso)
     val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         if (uri != null) {
             formViewModel.onImagenSeleccionada(uri)
         }
     }
 
+    /** Crea una URI temporal en caché para que la cámara escriba la foto. */
     fun createTempUri(): Uri {
         val tempFile = File.createTempFile("temp_img", ".jpg", context.cacheDir).apply {
             createNewFile()
@@ -90,7 +96,56 @@ fun ObservacionesScreen(
         )
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    // Cuando el permiso sea concedido, ejecutar la acción pendiente (abrir cámara)
+    LaunchedEffect(controlPermiso.permisoConcedido) {
+        if (controlPermiso.permisoConcedido) {
+            accionPendiente?.invoke()
+            accionPendiente = null
+        }
+    }
+
+    // Activar el diálogo de rationale cuando el sistema lo indique
+    LaunchedEffect(controlPermiso.mostrarRazon) {
+        if (controlPermiso.mostrarRazon) mostrarDialogoRazon = true
+    }
+
+    // Si el permiso fue denegado permanentemente, mostrar Snackbar con acceso a Ajustes
+    LaunchedEffect(controlPermiso.denegadoPermanente) {
+        if (controlPermiso.denegadoPermanente) {
+            val resultado = snackbarHostState.showSnackbar(
+                message = "Permiso de cámara denegado permanentemente. Actívalo en Ajustes.",
+                actionLabel = "Abrir Ajustes",
+                duration = SnackbarDuration.Long
+            )
+            if (resultado == SnackbarResult.ActionPerformed) {
+                abrirAjustesPermiso(context)
+            }
+            controlPermiso.restaurar()
+        }
+    }
+
+    // Resetear el guardado exitoso del formulario
+    LaunchedEffect(formState.guardadoExitoso) {
+        if (formState.guardadoExitoso) formViewModel.resetGuardadoExitoso()
+    }
+
+    // Diálogo de rationale: se muestra cuando el usuario negó el permiso una vez
+    if (mostrarDialogoRazon) {
+        DialogoRazonPermisoCamara(
+            enConfirmar = {
+                mostrarDialogoRazon = false
+                controlPermiso.restaurar()
+                controlPermiso.solicitar()
+            },
+            enDescartar = {
+                mostrarDialogoRazon = false
+                controlPermiso.restaurar()
+            }
+        )
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text("Observaciones", fontWeight = FontWeight.Bold) },
             navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver") } },
@@ -142,10 +197,19 @@ fun ObservacionesScreen(
                         }
 
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                            // ── Botón Cámara con verificación de permiso ──────────────
                             OutlinedButton(
                                 onClick = {
-                                    tempCameraUri = createTempUri()
-                                    tempCameraUri?.let { cameraLauncher.launch(it) }
+                                    val uri = createTempUri()
+                                    tempCameraUri = uri
+                                    if (controlPermiso.permisoConcedido) {
+                                        // Permiso ya concedido → lanzar cámara directamente
+                                        cameraLauncher.launch(uri)
+                                    } else {
+                                        // Permiso aún no concedido → guardar acción y solicitar
+                                        accionPendiente = { cameraLauncher.launch(uri) }
+                                        controlPermiso.solicitar()
+                                    }
                                 },
                                 modifier = Modifier.weight(1f)
                             ) {
@@ -153,6 +217,7 @@ fun ObservacionesScreen(
                                 Spacer(modifier = Modifier.width(8.dp))
                                 Text("Cámara")
                             }
+                            // ── Botón Galería (no requiere permiso peligroso) ─────────
                             OutlinedButton(
                                 onClick = { galleryLauncher.launch("image/*") },
                                 modifier = Modifier.weight(1f)
@@ -195,7 +260,18 @@ fun ObservacionesScreen(
                 }
             }
         }
-    }
+        } // Cierre del Column
+
+        // ── Snackbar anclado al fondo para feedback de permisos ──────────────────
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) { data ->
+            Snackbar {
+                Text(data.visuals.message)
+            }
+        }
+    } // Cierre del Box
 }
 
 @Composable

--- a/app/src/main/java/com/itec/donelio/presentation/util/CameraUtils.kt
+++ b/app/src/main/java/com/itec/donelio/presentation/util/CameraUtils.kt
@@ -21,10 +21,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
-// ---------------------------------------------------------------------------
-// Estado del permiso de cámara
-// ---------------------------------------------------------------------------
-
 /**
  * State holder que encapsula el estado mutable del permiso de cámara y las
  * acciones para solicitarlo o reiniciarlo. Diseñado para ser consumido desde
@@ -40,41 +36,19 @@ import androidx.core.content.ContextCompat
  */
 @Stable
 class EstadoPermisoCamara {
-
-    /** `true` si el permiso CAMERA fue concedido. */
     var permisoConcedido by mutableStateOf(false)
-
-    /** `true` si se debe mostrar el diálogo de rationale al usuario. */
     var mostrarRazon by mutableStateOf(false)
-
-    /** `true` si el permiso fue denegado permanentemente. */
     var denegadoPermanente by mutableStateOf(false)
 
-    /**
-     * Referencia mutable a la lambda que lanza la solicitud real del permiso.
-     * Es inyectada por [recordarPermisoCamara] después de inicializar el launcher.
-     */
     internal var onSolicitarPermiso: () -> Unit = {}
 
-    /**
-     * Lanza la solicitud del permiso de cámara al sistema operativo.
-     * Debe ser invocada desde un manejador de eventos (onClick, etc.).
-     */
     fun solicitar() = onSolicitarPermiso()
 
-    /**
-     * Restablece los estados intermedios ([mostrarRazon], [denegadoPermanente])
-     * luego de que el usuario interactuó con el diálogo de rationale o el Snackbar.
-     */
     fun restaurar() {
         mostrarRazon = false
         denegadoPermanente = false
     }
 }
-
-// ---------------------------------------------------------------------------
-// Composable principal: recordarPermisoCamara
-// ---------------------------------------------------------------------------
 
 /**
  * Composable que recuerda y gestiona el ciclo de vida completo del permiso de
@@ -111,60 +85,41 @@ class EstadoPermisoCamara {
 @Composable
 fun recordarPermisoCamara(): EstadoPermisoCamara {
     val context = LocalContext.current
-
-    // Objeto de estado único y mutable que persiste durante la recomposición
     val estado = remember { EstadoPermisoCamara() }
 
-    // Leemos el estado real del permiso en cada recomposición.
-    // Esto garantiza que si el usuario vuelve desde Ajustes habiendo concedido
-    // el permiso manualmente, la UI se actualice sin reiniciar la pantalla.
     val estaYaConcedido = ContextCompat.checkSelfPermission(
         context,
         Manifest.permission.CAMERA
     ) == PackageManager.PERMISSION_GRANTED
 
-    // Solo actualizamos a 'true' desde aquí; el launcher maneja la actualización
-    // dinámica tras la solicitud en tiempo de ejecución.
     if (estaYaConcedido) {
         estado.permisoConcedido = true
     }
 
-    // El launcher que interactúa con el sistema para solicitar el permiso
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { esConcedido ->
         if (esConcedido) {
-            // Permiso aceptado por el usuario
             estado.permisoConcedido = true
             estado.mostrarRazon = false
             estado.denegadoPermanente = false
         } else {
-            // Permiso denegado: distinguir entre "primera vez" y "permanente"
-            // ActivityCompat.shouldShowRequestPermissionRationale es el helper
-            // recomendado que funciona correctamente con ComponentActivity de Compose.
             val debeJustificar = ActivityCompat.shouldShowRequestPermissionRationale(
                 context as androidx.activity.ComponentActivity,
                 Manifest.permission.CAMERA
             )
             if (debeJustificar) {
-                // Primera denegación: mostrar rationale y dar otra oportunidad
                 estado.mostrarRazon = true
             } else {
-                // Segunda denegación o "No volver a preguntar": denegado permanente
                 estado.denegadoPermanente = true
             }
         }
     }
 
-    // Inyectamos el callback real del launcher en el estado (actualizado en cada composición)
     estado.onSolicitarPermiso = { launcher.launch(Manifest.permission.CAMERA) }
 
     return estado
 }
-
-// ---------------------------------------------------------------------------
-// Diálogo de rationale (justificación)
-// ---------------------------------------------------------------------------
 
 /**
  * Diálogo informativo que explica al usuario por qué la aplicación necesita
@@ -204,10 +159,6 @@ fun DialogoRazonPermisoCamara(
         }
     )
 }
-
-// ---------------------------------------------------------------------------
-// Helper: abrir ajustes del sistema
-// ---------------------------------------------------------------------------
 
 /**
  * Abre la pantalla de configuración de la aplicación en los Ajustes del sistema.

--- a/app/src/main/java/com/itec/donelio/presentation/util/CameraUtils.kt
+++ b/app/src/main/java/com/itec/donelio/presentation/util/CameraUtils.kt
@@ -1,0 +1,226 @@
+package com.itec.donelio.presentation.util
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+// ---------------------------------------------------------------------------
+// Estado del permiso de cámara
+// ---------------------------------------------------------------------------
+
+/**
+ * State holder que encapsula el estado mutable del permiso de cámara y las
+ * acciones para solicitarlo o reiniciarlo. Diseñado para ser consumido desde
+ * [recordarPermisoCamara] en la capa de UI.
+ *
+ * Todos los campos son observables por Compose gracias a [mutableStateOf].
+ *
+ * @property permisoConcedido `true` si el permiso [Manifest.permission.CAMERA] fue otorgado.
+ * @property mostrarRazon `true` cuando el sistema indica que se debe mostrar una
+ *   justificación (rationale) antes de volver a solicitar el permiso.
+ * @property denegadoPermanente `true` cuando el usuario denegó el permiso de forma
+ *   permanente. En este caso se debe redirigir al usuario a Ajustes del sistema.
+ */
+@Stable
+class EstadoPermisoCamara {
+
+    /** `true` si el permiso CAMERA fue concedido. */
+    var permisoConcedido by mutableStateOf(false)
+
+    /** `true` si se debe mostrar el diálogo de rationale al usuario. */
+    var mostrarRazon by mutableStateOf(false)
+
+    /** `true` si el permiso fue denegado permanentemente. */
+    var denegadoPermanente by mutableStateOf(false)
+
+    /**
+     * Referencia mutable a la lambda que lanza la solicitud real del permiso.
+     * Es inyectada por [recordarPermisoCamara] después de inicializar el launcher.
+     */
+    internal var onSolicitarPermiso: () -> Unit = {}
+
+    /**
+     * Lanza la solicitud del permiso de cámara al sistema operativo.
+     * Debe ser invocada desde un manejador de eventos (onClick, etc.).
+     */
+    fun solicitar() = onSolicitarPermiso()
+
+    /**
+     * Restablece los estados intermedios ([mostrarRazon], [denegadoPermanente])
+     * luego de que el usuario interactuó con el diálogo de rationale o el Snackbar.
+     */
+    fun restaurar() {
+        mostrarRazon = false
+        denegadoPermanente = false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composable principal: recordarPermisoCamara
+// ---------------------------------------------------------------------------
+
+/**
+ * Composable que recuerda y gestiona el ciclo de vida completo del permiso de
+ * cámara ([Manifest.permission.CAMERA]) en tiempo de ejecución (runtime permission).
+ *
+ * Implementa el flujo recomendado por Android para permisos peligrosos (API 23+):
+ * 1. Si ya está concedido → [EstadoPermisoCamara.permisoConcedido] = `true` de inmediato.
+ * 2. Si se deniega por primera vez → activa [EstadoPermisoCamara.mostrarRazon].
+ * 3. Si se deniega permanentemente → activa [EstadoPermisoCamara.denegadoPermanente].
+ *
+ * Uso típico en un Composable:
+ * ```kotlin
+ * val controlPermiso = recordarPermisoCamara()
+ *
+ * OutlinedButton(onClick = {
+ *     if (controlPermiso.permisoConcedido) {
+ *         lanzarCamara()
+ *     } else {
+ *         accionPendiente = { lanzarCamara() }
+ *         controlPermiso.solicitar()
+ *     }
+ * }) { Text("Tomar foto") }
+ *
+ * if (controlPermiso.mostrarRazon) {
+ *     DialogoRazonPermisoCamara(
+ *         enConfirmar = { controlPermiso.restaurar(); controlPermiso.solicitar() },
+ *         enDescartar = { controlPermiso.restaurar() }
+ *     )
+ * }
+ * ```
+ *
+ * @return Un [EstadoPermisoCamara] estable que representa el estado actual del permiso.
+ */
+@Composable
+fun recordarPermisoCamara(): EstadoPermisoCamara {
+    val context = LocalContext.current
+
+    // Objeto de estado único y mutable que persiste durante la recomposición
+    val estado = remember { EstadoPermisoCamara() }
+
+    // Leemos el estado real del permiso en cada recomposición.
+    // Esto garantiza que si el usuario vuelve desde Ajustes habiendo concedido
+    // el permiso manualmente, la UI se actualice sin reiniciar la pantalla.
+    val estaYaConcedido = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.CAMERA
+    ) == PackageManager.PERMISSION_GRANTED
+
+    // Solo actualizamos a 'true' desde aquí; el launcher maneja la actualización
+    // dinámica tras la solicitud en tiempo de ejecución.
+    if (estaYaConcedido) {
+        estado.permisoConcedido = true
+    }
+
+    // El launcher que interactúa con el sistema para solicitar el permiso
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { esConcedido ->
+        if (esConcedido) {
+            // Permiso aceptado por el usuario
+            estado.permisoConcedido = true
+            estado.mostrarRazon = false
+            estado.denegadoPermanente = false
+        } else {
+            // Permiso denegado: distinguir entre "primera vez" y "permanente"
+            // ActivityCompat.shouldShowRequestPermissionRationale es el helper
+            // recomendado que funciona correctamente con ComponentActivity de Compose.
+            val debeJustificar = ActivityCompat.shouldShowRequestPermissionRationale(
+                context as androidx.activity.ComponentActivity,
+                Manifest.permission.CAMERA
+            )
+            if (debeJustificar) {
+                // Primera denegación: mostrar rationale y dar otra oportunidad
+                estado.mostrarRazon = true
+            } else {
+                // Segunda denegación o "No volver a preguntar": denegado permanente
+                estado.denegadoPermanente = true
+            }
+        }
+    }
+
+    // Inyectamos el callback real del launcher en el estado (actualizado en cada composición)
+    estado.onSolicitarPermiso = { launcher.launch(Manifest.permission.CAMERA) }
+
+    return estado
+}
+
+// ---------------------------------------------------------------------------
+// Diálogo de rationale (justificación)
+// ---------------------------------------------------------------------------
+
+/**
+ * Diálogo informativo que explica al usuario por qué la aplicación necesita
+ * acceso a la cámara. Debe mostrarse cuando [EstadoPermisoCamara.mostrarRazon]
+ * es `true`, es decir, cuando el usuario denegó el permiso por primera vez y
+ * el sistema indica que se debe justificar el pedido antes de reintentar.
+ *
+ * @param enConfirmar Callback invocado cuando el usuario acepta la justificación
+ *   y desea conceder el permiso.
+ * @param enDescartar Callback invocado cuando el usuario descarta el diálogo
+ *   sin conceder el permiso.
+ */
+@Composable
+fun DialogoRazonPermisoCamara(
+    enConfirmar: () -> Unit,
+    enDescartar: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = enDescartar,
+        title = { Text("Permiso de cámara requerido") },
+        text = {
+            Text(
+                "Para tomar fotos de las observaciones necesitamos acceso a " +
+                        "tu cámara. Este permiso solo se usa para adjuntar imágenes a " +
+                        "tus registros de campo."
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = enConfirmar) {
+                Text("Conceder permiso")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = enDescartar) {
+                Text("Cancelar")
+            }
+        }
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Helper: abrir ajustes del sistema
+// ---------------------------------------------------------------------------
+
+/**
+ * Abre la pantalla de configuración de la aplicación en los Ajustes del sistema.
+ * Útil cuando el permiso fue denegado permanentemente ([EstadoPermisoCamara.denegadoPermanente]
+ * = `true`) y el usuario debe habilitarlo manualmente desde
+ * [Settings.ACTION_APPLICATION_DETAILS_SETTINGS].
+ *
+ * @param context Contexto de Android necesario para lanzar el [Intent].
+ */
+fun abrirAjustesPermiso(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}


### PR DESCRIPTION
## Resumen
Este Pull Request resuelve el **Issue #283** (Crash crítico de seguridad al intentar abrir la cámara sin solicitar el permiso en runtime, introducido a partir de Android 6.0).

## Cambios realizados
- **Arquitectura:** Se creó el módulo `CameraUtils.kt` en la capa `presentation/util/` para abstraer toda la lógica de los permisos de hardware (State Holder, Rationale Dialog, Intents al SO), manteniendo la Clean Architecture y evitando ensuciar el código de la UI.
- **Flujos manejados:**
  - Permiso ya concedido (abre cámara normal).
  - Permiso denegado por primera vez (muestra justificación `DialogoRazonPermisoCamara`).
  - Permiso denegado permanentemente (muestra `Snackbar` invitando al usuario a abrir los Ajustes del sistema).
- **Limpieza (Style):** Se removieron los comentarios redundantes en la lógica de Jetpack Compose para mantener un código limpio, conservando solo la documentación de API pública (KDoc).
- **Documentación:** Se añadieron los escenarios formales de prueba (Test 9.1 a 9.3) al `plan_de_pruebas.md`.

## Issues relacionados
Fixes #283